### PR TITLE
Fix spelling on Image Tags page

### DIFF
--- a/docker/content/docs/tags/index.md
+++ b/docker/content/docs/tags/index.md
@@ -17,7 +17,7 @@ tags:
   - Tags
 ---
 
-## Explainations
+## Explanations
 
 - _Extended_ represents the extended version of Hugo.
 - Image tags start with _reg_ represent the regular (standard) version of Hugo.

--- a/docker/layouts/shortcodes/docker-image-tags.html
+++ b/docker/layouts/shortcodes/docker-image-tags.html
@@ -3,7 +3,7 @@
   {{- printf "### `%s`\n" .name }}
   {{- printf "![Size](https://img.shields.io/docker/image-size/hugomods/hugo/%s?style=flat-square&height=32)\n" .name }}
   {{- printf "```sh\ndocker pull hugomods/hugo:%s\n```\n" .name }}
-  {{- printf "For sepcified version.\n" }}
+  {{- printf "For specified version.\n" }}
   {{- printf "```sh\ndocker pull hugomods/hugo:%s\n```\n" (cond (eq .name "latest") "<version>" (printf "%s-<version>" .name)) | safeHTML }}
   {{- printf "| Extended | Go  | Node.js | NPM | Git | Dart Sass | \n" }}
   {{- printf "| :------: | :-: | :-----: | :-: | :-: | :-------: |\n" }}


### PR DESCRIPTION
Fix spelling on Image Tags page: https://docker.hugomods.com/docs/tags/.